### PR TITLE
fix(normalize): fix root.hasOwnProperty

### DIFF
--- a/src/GraphQLNormalizr.js
+++ b/src/GraphQLNormalizr.js
@@ -113,7 +113,7 @@ export function GraphQLNormalizr ({
 
     let warned = false
     ;(function walk (root, path = '') {
-      if (root && root.hasOwnProperty('pageInfo') && !useConnections) {
+      if (root && Object.prototype.hasOwnProperty.call(root, 'pageInfo') && !useConnections) {
         process.env.NODE_ENV !== 'production' &&
           !warned &&
           // eslint-disable-next-line


### PR DESCRIPTION
Objects created with Object.create() do not have a hasOwnProperty function. Using Object.prototype.hasOwnProperty.call(root, 'pageInfo') is safer.

Somewhere in a package I'm using, nodes are created in a way where they don't have a hasOwnProperty. This change fixed it for me.